### PR TITLE
restrict PSP usage in Clusterrole to 'gatekeeper-admin' PSP

### DIFF
--- a/charts/gatekeeper/templates/gatekeeper-manager-role-clusterrole.yaml
+++ b/charts/gatekeeper/templates/gatekeeper-manager-role-clusterrole.yaml
@@ -64,6 +64,8 @@ rules:
   - watch
 - apiGroups:
   - policy
+  resourceNames:
+  - gatekeeper-admin
   resources:
   - podsecuritypolicies
   verbs:


### PR DESCRIPTION
**What this PR does / why we need it**:
more restrictive PSP usage permission, see #6 

**Which issue(s) this PR fixes**
fixes #6 

**Special notes for your reviewer**:
